### PR TITLE
feat: support UltraHonk

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,13 @@ it("proves and verifies on-chain", async () => {
   expect(result).to.eq(true);
 
   // You can also verify in JavaScript.
-  const resultJs = await backend.verifyProof({
-    proof,
-    publicInputs: [String(input.y)],
-  });
+  const resultJs = await backend.verifyProof(
+    {
+      proof,
+      publicInputs: [String(input.y)],
+    },
+    { keccak: true },
+  );
   expect(resultJs).to.eq(true);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ export default {
 };
 ```
 
+Change the proof flavor. It will generate different Solidity verifiers. If you switch to `ultra_plonk`, use `noir.getCircuit(name, UltraPlonkBackend)` to get ultra plonk backend.
+
+```js
+export default {
+  noir: {
+    // default is "ultra_keccak_honk"
+    flavor: "ultra_plonk",
+    // you can also specify multiple flavors
+    flavor: ["ultra_keccak_honk", "ultra_plonk"],
+  },
+};
+```
+
 The default folder where Noir is located is `noir`. You can change it in `hardhat.config.js`:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ Use the verifier contract in Solidity:
 
 ```solidity
 // contracts/MyContract.sol
-import {UltraVerifier} from "../noir/target/my_noir.sol";
+import {HonkVerifier} from "../noir/target/my_noir.sol";
 
 contract MyContract {
-    UltraVerifier public verifier = new UltraVerifier();
+    HonkVerifier public verifier = new HonkVerifier();
 
     function verify(bytes calldata proof, uint256 y) external view returns (bool) {
         bytes32[] memory publicInputs = new bytes32[](1);
@@ -110,7 +110,9 @@ it("proves and verifies on-chain", async () => {
   const { noir, backend } = await hre.noir.getCircuit("my_noir");
   const input = { x: 1, y: 2 };
   const { witness } = await noir.execute(input);
-  const { proof, publicInputs } = await backend.generateProof(witness);
+  const { proof, publicInputs } = await backend.generateProof(witness, {
+    keccak: true,
+  });
   // it matches because we marked y as `pub` in `main.nr`
   expect(BigInt(publicInputs[0])).to.eq(BigInt(input.y));
 
@@ -141,7 +143,7 @@ output of `npx hardhat help example`
 
 This plugin extends the Hardhat Runtime Environment by adding a `noir` field.
 
-You can call `hre.noir.getCircuit(name)` to get a compiled circuit JSON.
+You can call `hre.noir.getCircuit(name, backendClass)` to get a compiled circuit JSON.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ export default {
     // default is "ultra_keccak_honk"
     flavor: "ultra_plonk",
     // you can also specify multiple flavors
-    flavor: ["ultra_keccak_honk", "ultra_plonk"],
+    // flavor: ["ultra_keccak_honk", "ultra_plonk"],
   },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ it("proves and verifies on-chain", async () => {
   expect(BigInt(publicInputs[0])).to.eq(BigInt(input.y));
 
   // Verify the proof on-chain
-  const result = await contract.verify(proof, input.y);
+  // slice the proof to remove length information
+  const result = await contract.verify(proof.slice(4), input.y);
   expect(result).to.eq(true);
 
   // You can also verify in JavaScript.

--- a/src/Noir.ts
+++ b/src/Noir.ts
@@ -64,7 +64,6 @@ export async function getTarget(noirDir: string | HardhatConfig) {
 
 export type ProofFlavor = keyof typeof ProofFlavor;
 export const ProofFlavor = {
-  ultra_honk: "ultra_honk",
   ultra_keccak_honk: "ultra_keccak_honk",
   ultra_plonk: "ultra_plonk",
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { extendConfig, extendEnvironment } from "hardhat/config";
 import { HardhatPluginError, lazyObject } from "hardhat/plugins";
 import { HardhatConfig, HardhatUserConfig } from "hardhat/types";
 import path from "path";
-import { NoirExtension } from "./Noir";
+import { NoirExtension, ProofFlavor } from "./Noir";
 import "./tasks";
 import "./type-extensions";
 import { PLUGIN_NAME } from "./utils";
@@ -54,9 +54,15 @@ extendConfig(
           `cannot infer bb version for noir@${version}. Please specify \`noir.bbVersion\` in Hardhat config`,
         );
       }
+      const flavor: ProofFlavor[] = u.flavor
+        ? Array.isArray(u.flavor)
+          ? u.flavor
+          : [u.flavor]
+        : [ProofFlavor.ultra_keccak_honk];
       return {
         version,
         bbVersion,
+        flavor,
         skipNargoWorkspaceCheck: u.skipNargoWorkspaceCheck ?? false,
       };
     }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -114,13 +114,6 @@ async function generateSolidityVerifier(
   targetDir: string,
   flavor: ProofFlavor,
 ) {
-  if (flavor === "ultra_honk") {
-    console.log(
-      `Skipping ${flavor} verifier generation for ${file}. If you want to generate it, use ${ProofFlavor.ultra_keccak_honk} instead.`,
-    );
-    return;
-  }
-
   const path = await import("path");
 
   const runCommand = makeRunCommand(config.paths.noir);

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -3,7 +3,7 @@
 // To extend one of Hardhat's types, you need to import the module where it has been defined, and redeclare it.
 import "hardhat/types/config";
 import "hardhat/types/runtime";
-import { NoirExtension } from "./Noir";
+import { NoirExtension, ProofFlavor } from "./Noir";
 
 declare module "hardhat/types/config" {
   // This is an example of an extension to one of the Hardhat config values.
@@ -29,12 +29,15 @@ declare module "hardhat/types/config" {
     noir: {
       version: string;
       bbVersion?: string;
+      flavor?: ProofFlavor | ProofFlavor[];
       skipNargoWorkspaceCheck?: boolean;
     };
   }
 
   export interface HardhatConfig {
-    noir: NonNullable<Required<HardhatUserConfig["noir"]>>;
+    noir: Omit<Required<HardhatUserConfig["noir"]>, "flavor"> & {
+      flavor: ProofFlavor[];
+    };
   }
 }
 

--- a/test/fixture-projects/hardhat-project/contracts/MyContract.sol
+++ b/test/fixture-projects/hardhat-project/contracts/MyContract.sol
@@ -4,9 +4,15 @@ pragma solidity ^0.8.27;
 import {HonkVerifier} from "../noir2/target/my_circuit.sol";
 
 contract MyContract {
-  HonkVerifier public verifier;
+    HonkVerifier public verifier = new HonkVerifier();
 
-  constructor(HonkVerifier _verifier) {
-    verifier = _verifier;
-  }
+    function verify(
+        bytes calldata proof,
+        uint256 y
+    ) external view returns (bool) {
+        bytes32[] memory publicInputs = new bytes32[](1);
+        publicInputs[0] = bytes32(y);
+        bool result = verifier.verify(proof, publicInputs);
+        return result;
+    }
 }

--- a/test/fixture-projects/hardhat-project/contracts/MyContract.sol
+++ b/test/fixture-projects/hardhat-project/contracts/MyContract.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity ^0.8.27;
 
-import {UltraVerifier} from "../noir2/target/my_circuit.sol";
+import {HonkVerifier} from "../noir2/target/my_circuit.sol";
 
 contract MyContract {
-  UltraVerifier public verifier;
+  HonkVerifier public verifier;
 
-  constructor(UltraVerifier _verifier) {
+  constructor(HonkVerifier _verifier) {
     verifier = _verifier;
   }
 }

--- a/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -21,6 +21,7 @@ const config: HardhatUserConfig = {
   },
   noir: {
     version: TEST_NOIR_VERSION,
+    flavor: ["ultra_keccak_honk", "ultra_plonk"],
   },
 };
 

--- a/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -1,4 +1,5 @@
 // We load the plugin here.
+import "@nomicfoundation/hardhat-ethers";
 import { HardhatUserConfig } from "hardhat/types";
 
 import "../../../src/index";

--- a/test/noir.test.ts
+++ b/test/noir.test.ts
@@ -65,7 +65,7 @@ describe("Integration tests examples", function () {
       expect(BigInt(publicInputs[0])).to.eq(BigInt(input.y));
 
       // Verify the proof on-chain
-      const result = await contract.verify(proof, [
+      const result = await contract.verify(proof.slice(4), [
         this.hre.ethers.toBeHex(input.y, 32),
       ]);
       expect(result).to.eq(true);

--- a/test/noir.test.ts
+++ b/test/noir.test.ts
@@ -71,10 +71,13 @@ describe("Integration tests examples", function () {
       expect(result).to.eq(true);
 
       // You can also verify in JavaScript.
-      const resultJs = await backend.verifyProof({
-        proof,
-        publicInputs: [String(input.y)],
-      });
+      const resultJs = await backend.verifyProof(
+        {
+          proof,
+          publicInputs: [String(input.y)],
+        },
+        { keccak: true },
+      );
       expect(resultJs).to.eq(true);
     });
 

--- a/test/noir.test.ts
+++ b/test/noir.test.ts
@@ -50,7 +50,7 @@ describe("Integration tests examples", function () {
 
       // Deploy a verifier contract
       const contractFactory =
-        await this.hre.ethers.getContractFactory("HonkVerifier");
+        await this.hre.ethers.getContractFactory("MyContract");
       const contract = await contractFactory.deploy();
       await contract.waitForDeployment();
 
@@ -65,9 +65,7 @@ describe("Integration tests examples", function () {
       expect(BigInt(publicInputs[0])).to.eq(BigInt(input.y));
 
       // Verify the proof on-chain
-      const result = await contract.verify(proof.slice(4), [
-        this.hre.ethers.toBeHex(input.y, 32),
-      ]);
+      const result = await contract.verify(proof.slice(4), input.y);
       expect(result).to.eq(true);
 
       // You can also verify in JavaScript.


### PR DESCRIPTION
Switches to UltraHonk by default. Introduces `flavor` config variable. Supported values are `ultra_keccak_honk` (default), `ultra_plonk` or both as an array. Solidity verifiers are generated according to the `flavor` set in the config. 

Minimum supported bb.js version is 0.67.0 due to `ultra_keccak_honk` proof generation introduction only in that version: https://github.com/AztecProtocol/aztec-packages/pull/10489.